### PR TITLE
Prefer selecting 'bundle' artifacts over 'non-bundle' artifacts

### DIFF
--- a/src/main/twirl/scalajs/selectScript.scala.html
+++ b/src/main/twirl/scalajs/selectScript.scala.html
@@ -6,7 +6,8 @@
 
 @defining(s"${projectName.toLowerCase}") { name =>
   @{
-    Seq(s"$name-opt.js", s"$name-fastopt.js", s"$name-opt-bundle.js", s"$name-fastopt-bundle.js")
-      .find(resourceExists).map(name => jsScript(assets(name), htmlAttributes))
+    val possibleBuildArtifactSuffixes = Seq("opt-bundle", "fastopt-bundle", "opt", "fastopt")
+    possibleBuildArtifactSuffixes.map(suffix => s"$name-$suffix.js")
+      .find(resourceExists).map(filename => jsScript(assets(filename), htmlAttributes))
   }
 }


### PR DESCRIPTION
When using the [scalajs-bundler](https://github.com/scalacenter/scalajs-bundler) sbt plugin and deploying to Heroku, I've had problems with the `project-opt.js` artifact being selected over the `project-opt-bundle.js` artifact which is required - I _think_ `-bundle` artifacts should be preferred - `selectScript.scala.html` only selects one, so it should be the `-bundle` one.

This follows on from https://github.com/vmunier/scalajs-scripts/pull/17.

Until this fix is released, a workaround for this issue is to hack the value of the `resourceExists` function sent to `selectScript.scala.html`, eg adding `&& name.contains("-bundle")`:

```
@scalajs.html.scripts(
    buildinfo.BuildInfo.name,
    routes.Assets.versioned(_).toString,
    name => getClass.getResource(s"/public/$name") != null && name.contains("-bundle")
)
```